### PR TITLE
Kj/fix memoize

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,8 @@ julia = "1.5"
 
 [extras]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Logging", "Test"]
+test = ["Logging", "Test", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpinGlassTensors"
 uuid = "7584fc6a-5a23-4eeb-8277-827aab0146ea"
 authors = ["Łukasz Pawela <lukasz.pawela@gmail.com>", "Konrad Jałowiecki <dexter2206@gmail.com>", "Bartłomiej Gardas <bartek.gardas@gmail.com>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/base.jl
+++ b/src/base.jl
@@ -24,6 +24,7 @@ for (T, N) ∈ ((:PEPSRow, 5), (:MPO, 4), (:MPS, 3))
 
         @inline Base.setindex!(a::$AT, A::AbstractArray{<:Number, $N}, i::Int) = a.tensors[i] = A
         @inline bond_dimension(a::$AT) = maximum(size.(a.tensors, $N))
+        Base.hash(a::$T, h::UInt) = hash(a.tensors, h)
         Base.copy(a::$T) = $T(copy(a.tensors))
 
         @inline Base.eltype(::$AT{T}) where {T} = T

--- a/src/contractions.jl
+++ b/src/contractions.jl
@@ -43,7 +43,7 @@ function left_env(ϕ::AbstractMPS, ψ::AbstractMPS)
     L
 end
 
-@memoize function left_env(ϕ::AbstractMPS, σ::Vector{Int})
+@memoize Dict function left_env(ϕ::AbstractMPS, σ::Vector{Int})
     l = length(σ)
     if l == 0
         L = [1.]

--- a/src/contractions.jl
+++ b/src/contractions.jl
@@ -76,7 +76,7 @@ function right_env(ϕ::AbstractMPS, ψ::AbstractMPS)
     R
 end
 
-@memoize function right_env(ϕ::AbstractMPS{T}, W::AbstractMPO{T}, σ::Union{Vector, NTuple}) where {T}
+@memoize Dict function right_env(ϕ::AbstractMPS{T}, W::AbstractMPO{T}, σ::Union{Vector, NTuple}) where {T}
     l = length(σ)
     #k = length(ϕ)
     k = length(W)

--- a/test/base.jl
+++ b/test/base.jl
@@ -181,7 +181,7 @@ end
     @testset "Equal tuples with MPS and MPO have the same hash" begin
         tuple_1 = (ψ, W, [1, 2, 3])
         tuple_2 = (ϕ, V, [1, 2, 3])
-        @test  tuple_1 == tuple_2
+        @test tuple_1 == tuple_2
         @test hash(tuple_1) == hash(tuple_2)
     end
 end

--- a/test/base.jl
+++ b/test/base.jl
@@ -156,3 +156,32 @@ end
 end
 
 end
+
+
+@testset "Objects with equal tensors have the same hash" begin
+    D = 10
+    d = 4
+    sites = 5
+    T = ComplexF64
+
+    ψ = randn(MPS{T}, sites, D, d)
+    ϕ = copy(ψ)
+
+    W = randn(MPO{T}, sites, D, d)
+    V = copy(W)
+
+    @testset "Equal MPSs have the same hash" begin
+        @test hash(ψ) == hash(ϕ)
+    end
+
+    @testset "Equal MPOs have the same hash" begin
+        @test hash(W) == hash(V)
+    end
+
+    @testset "Equal tuples with MPS and MPO have the same hash" begin
+        tuple_1 = (ψ, W, [1, 2, 3])
+        tuple_2 = (ϕ, V, [1, 2, 3])
+        @test  tuple_1 == tuple_2
+        @test hash(tuple_1) == hash(tuple_2)
+    end
+end

--- a/test/memoization.jl
+++ b/test/memoization.jl
@@ -37,3 +37,32 @@ T = Float64
     # No additional calls should be made, thus size of cache should still be equal to 4
     @test length(memoize_cache(left_env)) == 4
 end
+
+
+@testset "Results of right_env are correctly cached" begin
+    empty!(memoize_cache(right_env))
+
+    Random.seed!(42)
+
+    ψ = randn(MPS{T}, sites, D, d) 
+    ϕ = copy(ψ)
+
+    W = randn(MPO{T}, sites, D, d)
+    V = copy(W)
+
+    σ = [2, 1, 1, 2, 1]
+    η = copy(σ)
+    
+    envs = [
+        right_env(mps, mpo, v) for mps in (ψ, ϕ) for mpo ∈ (W, V) for v ∈ (σ, η)
+    ]
+    
+    @testset "Calls made with equal arguments results in a cache hit" begin
+        # Should result in 6 calls total (top-level + 5 recursive)
+        @test length(memoize_cache(right_env)) == 6
+    end
+
+    @testset "Cached results are equal to the ones computed during first call" begin
+        @test all(env->env==envs[1], envs)
+    end
+end

--- a/test/memoization.jl
+++ b/test/memoization.jl
@@ -9,7 +9,7 @@ d = 3
 sites = 5
 T = Float64
 
-@testset "Calling left_env with equal arguments results in a cache hit" begin
+@testset "Results of left_env are correctly cached" begin
     # Cache is global, therefore we need to reset it to obtain meaningful
     # results here.
     empty!(memoize_cache(left_env))
@@ -22,20 +22,16 @@ T = Float64
     σ = [1, 2, 3]
     η = [1, 2, 3]
 
-    # Should result in 4 calls total (top-level + 3 recursive)
-    env_1 = left_env(ψ, σ) 
-    @test length(memoize_cache(left_env)) == 4
+    envs = [left_env(mps, v) for mps in (ψ, ϕ) for v ∈ (σ, η)]
 
-    env_2 = left_env(ψ, η)
+    @testset "Calls made with equal arguments result in a cache hit" begin
+        # Should result in 4 calls total (top-level + 3 recursive)    
+        @test length(memoize_cache(left_env)) == 4
+    end
 
-    env_3 = left_env(ϕ, σ)
-    
-    env_4 = left_env(ϕ, η)
-    
-    @test env_1 == env_2 == env_3 == env_4
-
-    # No additional calls should be made, thus size of cache should still be equal to 4
-    @test length(memoize_cache(left_env)) == 4
+    @testset "Cached results are equal to the ones computed during first call" begin
+        @test all(env->env==envs[1], envs)
+    end    
 end
 
 
@@ -57,7 +53,7 @@ end
         right_env(mps, mpo, v) for mps in (ψ, ϕ) for mpo ∈ (W, V) for v ∈ (σ, η)
     ]
     
-    @testset "Calls made with equal arguments results in a cache hit" begin
+    @testset "Calls made with equal arguments result in a cache hit" begin
         # Should result in 6 calls total (top-level + 5 recursive)
         @test length(memoize_cache(right_env)) == 6
     end

--- a/test/memoization.jl
+++ b/test/memoization.jl
@@ -1,0 +1,39 @@
+using Memoize
+using Random
+using Test
+using SpinGlassTensors
+
+
+D = 10
+d = 3
+sites = 5
+T = Float64
+
+@testset "Calling left_env with equal arguments results in a cache hit" begin
+    # Cache is global, therefore we need to reset it to obtain meaningful
+    # results here.
+    empty!(memoize_cache(left_env))
+
+    Random.seed!(69)
+
+    ψ = randn(MPS{T}, sites, D, d) 
+    ϕ = copy(ψ)
+
+    σ = [1, 2, 3]
+    η = [1, 2, 3]
+
+    # Should result in 4 calls total (top-level + 3 recursive)
+    env_1 = left_env(ψ, σ) 
+    @test length(memoize_cache(left_env)) == 4
+
+    env_2 = left_env(ψ, η)
+
+    env_3 = left_env(ϕ, σ)
+    
+    env_4 = left_env(ϕ, η)
+    
+    @test env_1 == env_2 == env_3 == env_4
+
+    # No additional calls should be made, thus size of cache should still be equal to 4
+    @test length(memoize_cache(left_env)) == 4
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,14 +23,13 @@ my_tests = []
 #     )
 # end
 
-my_tests = []
-
-push!(my_tests,
-      "base.jl",
-      "contractions.jl",
-      "compressions.jl",
-      "identities.jl",
-)
+my_tests = [
+    "base.jl",
+    "memoization.jl",
+    "contractions.jl",
+    "compressions.jl",
+    "identities.jl"
+]
 
 for my_test in my_tests
     include(my_test)


### PR DESCRIPTION
This fixes memoization in `right_env` and `left_env`. 

To this end, we needed to define `Base.hash` for MPS and MPO, since by default hashes of mutable structures are identity-based. Hence, even changing cache structure in `@memoize` to `Dict` didn't fully help, as equal MPS/MPO were still producing new dictionary entries.

Note that in the long-term we should switch to immutable MPS/MPO, because the current implementation would break silently if one modified in-place any of such objects present in the cache, potentially resulting in hard to debug out-of-memory errors.

Added tests verify the following:
- Equality of hashes of equal MPS/MPO objects, and tuples containing them
- Correctness of results obtained from the cache
- Hitting cache when using equal argument tuples