### PR TITLE
Fix comparison of IdentityMPS

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpinGlassTensors"
 uuid = "7584fc6a-5a23-4eeb-8277-827aab0146ea"
 authors = ["Łukasz Pawela <lukasz.pawela@gmail.com>", "Konrad Jałowiecki <dexter2206@gmail.com>", "Bartłomiej Gardas <bartek.gardas@gmail.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/base.jl
+++ b/src/base.jl
@@ -25,14 +25,14 @@ for (T, N) ∈ ((:PEPSRow, 5), (:MPO, 4), (:MPS, 3))
         @inline Base.setindex!(a::$AT, A::AbstractArray{<:Number, $N}, i::Int) = a.tensors[i] = A
         @inline bond_dimension(a::$AT) = maximum(size.(a.tensors, $N))
         Base.hash(a::$T, h::UInt) = hash(a.tensors, h)
+        @inline Base.:(==)(a::$T, b::$T) = a.tensors == b.tensors
+        @inline Base.:(≈)(a::$T, b::$T)  = a.tensors ≈ b.tensors
         Base.copy(a::$T) = $T(copy(a.tensors))
 
         @inline Base.eltype(::$AT{T}) where {T} = T
     end
 end
 
-@inline Base.:(==)(a::AbstractTensorNetwork, b::AbstractTensorNetwork) = a.tensors == b.tensors
-@inline Base.:(≈)(a::AbstractTensorNetwork, b::AbstractTensorNetwork)  = a.tensors ≈ b.tensors
 
 @inline Base.getindex(a::AbstractTensorNetwork, i) = getindex(a.tensors, i)
 @inline Base.iterate(a::AbstractTensorNetwork) = iterate(a.tensors)

--- a/test/identities.jl
+++ b/test/identities.jl
@@ -1,3 +1,6 @@
+using Random
+
+
 ψ = randn(MPS{Float64}, 4, 3, 2)
 O = randn(MPO{Float64}, 4, 3, 2)
 
@@ -58,4 +61,20 @@ end
         @test ndims(B) == 4
         @test norm(B) == 1
     end
+end
+
+@testset "IdentityMPS is only equal to itself" begin    
+    @test IdentityMPS() == IdentityMPS()
+
+    true_identity = IdentityMPS()
+    tensors = [true_identity[i] for i in 1:4]
+
+    @test IdentityMPS() != MPS(tensors)
+    @test MPS(tensors) != IdentityMPS()
+
+    Random.seed!(123)
+    another_mps = randn(MPS{Float64}, 5, 3, 4)
+
+    @test IdentityMPS() != another_mps
+    @test another_mps != IdentityMPS()
 end


### PR DESCRIPTION
Currently comparing `IdentityMPS` to other tensor networks is broken, which also breaks memoization whenever `IdentityMPS` is cached. This fixes the issue by implementing tensor-by-tensor comparison for concrete types instead of abstract ones. Note that in this implementation, manually constructed identity `MPS` is not equal to `IdentityMPS` (although this corner case should be rather rare).